### PR TITLE
Support international/non-ASCII characters; Add preview

### DIFF
--- a/Civi/Api4/Action/Contact/ApplyThethe.php
+++ b/Civi/Api4/Action/Contact/ApplyThethe.php
@@ -1,0 +1,76 @@
+<?php
+namespace Civi\Api4\Action\Contact;
+
+use Civi\Api4\Generic\BasicBatchAction;
+use Civi\Api4\Generic\Result;
+use Civi\Api4\Contact;
+
+/**
+ * Updates organizations' sort_name fields.
+ */
+class ApplyThethe extends BasicBatchAction {
+
+  /**
+   * Only do this where a pattern applies?
+   *
+   * You may wish to disable this if you need to re-create sort_names after removing a pattern.
+   *
+   * @default TRUE
+   * @var bool
+   */
+  protected $whereApplicable = TRUE;
+
+  /**
+   *
+   * This function should return an array with an output record for the item.
+   *
+   * @param array $item
+   * @return array
+   * @throws \Civi\API\Exception\NotImplementedException
+   */
+  protected function doTask($item) {
+    $org = Contact::get($this->getCheckPermissions())
+      ->addWhere('id', '=', $item['id'])
+      ->addSelect('organization_name', 'sort_name')
+      ->execute()->first();
+    if (empty($org['organization_name'])) {
+      return $item;
+    }
+    $munged = thethe_munge($org['organization_name']);
+    if (($org['sort_name'] ?? '') !== $munged) {
+      Contact::update($this->getCheckPermissions())
+        ->addWhere('id', '=', $item['id'])
+        ->addValue('sort_name', $munged)
+        ->execute();
+      $org['sort_name'] = $munged;
+    }
+    return $org;
+  }
+
+  public function _run(Result $result) {
+    if ($this->whereApplicable) {
+      $orGroup = [];
+      foreach (thethe_get_setting('prefix') as $string) {
+        if (!empty($string)) {
+          $orGroup[] = ['organization_name', 'LIKE', "$string%"];
+        }
+      }
+      foreach (thethe_get_setting('suffix') as $string) {
+        if (!empty($string)) {
+          $orGroup[] = ['organization_name', 'LIKE', "%$string"];
+        }
+      }
+
+      foreach (thethe_get_setting('anywhere') as $string) {
+        if (!empty($string)) {
+          $orGroup[] = ['organization_name', 'LIKE', "%$string%"];
+        }
+      }
+      $this->where[] = ['OR', $orGroup];
+    }
+    $this->where[] = ['contact_type', '=', 'Organization'];
+
+    parent::_run($result);
+  }
+
+}

--- a/Civi/Api4/Action/Contact/PreviewThethe.php
+++ b/Civi/Api4/Action/Contact/PreviewThethe.php
@@ -1,0 +1,48 @@
+<?php
+namespace Civi\Api4\Action\Contact;
+
+use Civi\Api4\Generic\AbstractAction;
+use Civi\Api4\Generic\Result;
+use Civi\Api4\Contact;
+
+class PreviewThethe extends AbstractAction {
+
+  public function _run(Result $result) {
+    $testCases = [];
+
+    foreach (thethe_get_setting('prefix') as $string) {
+      $contact = Contact::get()
+        ->addSelect('organization_name')
+        ->addWhere('contact_type', '=', "Organization")
+        ->addWhere('organization_name', 'LIKE', "$string%")
+        ->setLimit(1)
+        ->execute()->first();
+      $testCases[$contact['id']] = $contact['organization_name'];
+    }
+
+    foreach (thethe_get_setting('suffix') as $string) {
+      $contact = Contact::get()
+        ->addSelect('organization_name')
+        ->addWhere('contact_type', '=', "Organization")
+        ->addWhere('organization_name', 'LIKE', "%$string")
+        ->setLimit(1)
+        ->execute()->first();
+      $testCases[$contact['id']] = $contact['organization_name'];
+    }
+
+    foreach (thethe_get_setting('anywhere') as $string) {
+      $contact = Contact::get()
+        ->addSelect('organization_name')
+        ->addWhere('contact_type', '=', "Organization")
+        ->addWhere('organization_name', 'LIKE', "%$string%")
+        ->setLimit(1)
+        ->execute()->first();
+      $testCases[$contact['id']] = $contact['organization_name'];
+    }
+
+    foreach ($testCases as $ctID => $orgName) {
+      $result[] = ['contact_id' => $ctID, 'organization_name' => $orgName, 'sort_name' => thethe_munge($orgName)];
+    }
+  }
+
+}

--- a/Civi/Api4/Action/Contact/PreviewThethe.php
+++ b/Civi/Api4/Action/Contact/PreviewThethe.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Civi\Api4\Action\Contact;
 
 use Civi\Api4\Generic\AbstractAction;
@@ -17,9 +18,12 @@ class PreviewThethe extends AbstractAction {
         ->addWhere('organization_name', 'LIKE', "$string%")
         ->setLimit(1)
         ->execute()->first();
-      $testCases[$contact['id']] = $contact['organization_name'];
+      if ($contact) {
+        $testCases[$contact['id']] = $contact['organization_name'];
+      }
     }
 
+    $notes = [];
     foreach (thethe_get_setting('suffix') as $string) {
       $contact = Contact::get()
         ->addSelect('organization_name')
@@ -27,7 +31,10 @@ class PreviewThethe extends AbstractAction {
         ->addWhere('organization_name', 'LIKE', "%$string")
         ->setLimit(1)
         ->execute()->first();
-      $testCases[$contact['id']] = $contact['organization_name'];
+      if ($contact) {
+        $testCases[$contact['id']] = $contact['organization_name'];
+      }
+      // $notes[] = "ct $contact[organization_name] included for suffix '$string'";
     }
 
     foreach (thethe_get_setting('anywhere') as $string) {
@@ -37,12 +44,14 @@ class PreviewThethe extends AbstractAction {
         ->addWhere('organization_name', 'LIKE', "%$string%")
         ->setLimit(1)
         ->execute()->first();
-      $testCases[$contact['id']] = $contact['organization_name'];
+      if ($contact) {
+        $testCases[$contact['id']] = $contact['organization_name'];
+      }
     }
 
     foreach ($testCases as $ctID => $orgName) {
       $result[] = ['contact_id' => $ctID, 'organization_name' => $orgName, 'sort_name' => thethe_munge($orgName)];
     }
+    // $result['notes'] = $notes;
   }
-
 }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,12 @@ Having standardised sort names is also useful for doing deduping - sort_name can
 
 The extension also permits suffixes to be removed or strings to be removed from anywhere in the sort name. The prefixes and suffixes to be replaced can be configured under **Administer->Customize Data and Screens->Organization Sort Name Settings** (per the screenshot above).
 
-Note: The patterns are applied *in order*. So prefixes of `'the ', 'the university of '`will not fix `The University of Life`, because once the 'the' is removed, the second pattern no longer matches. So you would need to swap the order (or use just `'university of '` instead which *would* apply).
+Notes:
+
+- The patterns are applied *in order*. So prefixes of `'the ', 'the university of '`will not fix `The University of Life`, because once the 'the' is removed, the second pattern no longer matches. So you would need to swap the order (or use just `'university of '` instead which *would* apply).
+
+- If you want to replace single quotes you have to 'escape' them with 
+  a backslash. For example, you could enter `"'\'s'"` as an anywhere pattern to change "Mary's" to "Mary". If doing this also watchout that *Mary’s* is not the same as *Mary's* and would need another pattern for the ’ character!
 
 The extension is licensed under [AGPL-3.0](LICENSE.txt).
 
@@ -61,9 +66,10 @@ This can be useful to figure out if you put the spaces in the right places etc.
 - This only addresses Organizations. It could easily be extended to Households but more
 core changes would be needed for any changes to Individuals.
 
-- The prefix and suffix patterns you choose are not case-sensitive; entering 
-  `'The '` is the same as entering `'the '`. The *anywhere* patterns will only be removed if the `organization_name` contains the *lowercase* version of the pattern. So an anywhere pattern of 'and' will not remove from 'This And That'.
+- The *prefix* and *suffix* patterns you choose are **not** case-sensitive; entering `'The '` as a pattern is the same as entering `'the '`.
 
+- The *anywhere* patterns will only be removed if the `organization_name` 
+  contains the *lowercase* version of the pattern. So an anywhere pattern of 'and ' will not remove *and* from an organisation called 'This And That'.
 
 ## Changes
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ This extension alters the sort name saved for organisations. It allows you to re
 
 Having standardised sort names is also useful for doing deduping - sort_name can be used as a field in a rule and The Justice League can then be deduped with Justice League.
 
-The extension also permits suffixes to be removed or strings to be removed from anywhere in the sort name. The prefixes and suffixes to be replaced can be configured under Administer->Customize Data and Screens->Organization Sort Name Settings (per the screenshot above).
+The extension also permits suffixes to be removed or strings to be removed from anywhere in the sort name. The prefixes and suffixes to be replaced can be configured under **Administer->Customize Data and Screens->Organization Sort Name Settings** (per the screenshot above).
+
+Note: The patterns are applied *in order*. So prefixes of `'the ', 'the university of '`will not fix `The University of Life`, because once the 'the' is removed, the second pattern no longer matches. So you would need to swap the order (or use just `'university of '` instead which *would* apply).
 
 The extension is licensed under [AGPL-3.0](LICENSE.txt).
 
@@ -46,7 +48,24 @@ of any organization that is created or edited. This difference will be most noti
 from quicksearch - especially in organizations that have turned off the Automatic Wildcard 
 search setting (turning this off gives a substantial performance improvement on larger sites)
 
+### Preview effects of settings
+
+If you have access to the API4 explorer, you can call `Contact.previewThethe`. This will
+look up one matching organization name for each of the strings you have set and
+return an array with the (unchanged) `organization_name` and the new `sort_name` (and the contact ID).
+
+This can be useful to figure out if you put the spaces in the right places etc.
+
 ## Known Issues
 
-This only addresses Organizations. It could easily be extended to Households but more
+- This only addresses Organizations. It could easily be extended to Households but more
 core changes would be needed for any changes to Individuals.
+
+- The prefix and suffix patterns you choose are not case-sensitive; entering 
+  `'The '` is the same as entering `'the '`. The *anywhere* patterns will only be removed if the `organization_name` contains the *lowercase* version of the pattern. So an anywhere pattern of 'and' will not remove from 'This And That'.
+
+
+## Changes
+
+Up to v 1.2, only ASCII characters were considered in a case-insensitive way; the pattern `université` would not match `UNIVERSITÉ`. As long as your PHP has the mbstring extension installed, this is fixed in later versions.
+

--- a/tests/phpunit/TheTheTest.php
+++ b/tests/phpunit/TheTheTest.php
@@ -58,9 +58,9 @@ class TheTheTest extends \PHPUnit\Framework\TestCase implements HeadlessInterfac
   /**
    */
   public function testCaseRules() {
-    Civi::settings()->set('thethe_org_prefix_strings', 'université de');
-    Civi::settings()->set('thethe_org_suffix_strings', ' Ltd');
-    Civi::settings()->set('thethe_org_anywhere_strings', ' and');
+    Civi::settings()->set('thethe_org_prefix_strings', "'université de'");
+    Civi::settings()->set('thethe_org_suffix_strings', "' Ltd'");
+    Civi::settings()->set('thethe_org_anywhere_strings', "' and'");
 
     // Test mbstring support.
     if (!function_exists('mb_strtolower')) {
@@ -74,6 +74,29 @@ class TheTheTest extends \PHPUnit\Framework\TestCase implements HeadlessInterfac
 
     // This test documents current behaviour; I'm not sure if this is *desired* behaviour or not.
     $this->assertEquals('This And That', thethe_munge('This And That'));
+  }
+
+  /**
+   * Test parsing the settings string/array.
+   *
+   * @dataProvider getSettingsData
+   */
+  public function testParseSetting($patternsString, $expectedArray) {
+    $this->assertEquals($expectedArray, thethe_parse_setting_value($patternsString));
+  }
+
+  /**
+   * Data provider for testGetSettings
+   */
+  protected function getSettingsData(): array {
+    return [
+      'empty string means no patterns' => ['', []],
+      'pattern with comma is ok' => ["','", [',']],
+      'unquoted' => ['the', ['the']],
+      'quoted' => ["'the '", ['the ']],
+      'php array' => [['the '], ['the ']],
+      'quoted csv empty item' => ["'the ','a ',", ['the ', 'a ']],
+    ];
   }
 
 }

--- a/tests/phpunit/TheTheTest.php
+++ b/tests/phpunit/TheTheTest.php
@@ -59,10 +59,21 @@ class TheTheTest extends \PHPUnit\Framework\TestCase implements HeadlessInterfac
    */
   public function testCaseRules() {
     Civi::settings()->set('thethe_org_prefix_strings', 'université de');
-    Civi::settings()->set('thethe_org_suffix_strings', 'Ltd');
-    Civi::settings()->set('thethe_org_anywhere_strings', ['and']);
+    Civi::settings()->set('thethe_org_suffix_strings', ' Ltd');
+    Civi::settings()->set('thethe_org_anywhere_strings', ' and');
 
+    // Test mbstring support.
+    if (!function_exists('mb_strtolower')) {
+      $this->markTestSkipped('Cannot test mbstring functions; not installed');
+      return;
+    }
     $this->assertEquals('Life', thethe_munge('UNIVERSITÉ de Life LTD'));
-    $this->assertEquals('This And That', thethe_munge('The And That'));
+
+    // This test is expected.
+    $this->assertEquals('This That', thethe_munge('This and That'));
+
+    // This test documents current behaviour; I'm not sure if this is *desired* behaviour or not.
+    $this->assertEquals('This And That', thethe_munge('This And That'));
   }
+
 }

--- a/tests/phpunit/TheTheTest.php
+++ b/tests/phpunit/TheTheTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Civi\Api4\Contact;
 use CRM_Thethe_ExtensionUtil as E;
 use Civi\Test\HeadlessInterface;
 use Civi\Test\HookInterface;
@@ -22,6 +23,8 @@ use Civi\Test\TransactionalInterface;
 class TheTheTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
 
   use Civi\Test\Api3TestTrait;
+
+  protected $contactIdsToDelete = [];
 
   /**
    * Set up for headless tests.
@@ -98,6 +101,68 @@ class TheTheTest extends \PHPUnit\Framework\TestCase implements HeadlessInterfac
       'quoted csv empty item' => ["'the ','a ',", ['the ', 'a ']],
       'Can include single quotes escaped with backslash' => ["'\\''", ["'"]],
     ];
+  }
+
+  /**
+   * Test the Contact.applyThethe action.
+   */
+  public function testApply() {
+    // Do nothing for now.
+    Civi::settings()->set('thethe_org_suffix_strings', '');
+    Civi::settings()->set('thethe_org_anywhere_strings', '');
+    Civi::settings()->set('thethe_org_prefix_strings', '');
+    $contacts = Contact::save(FALSE)
+      ->setDefaults([
+        'contact_type' => 'Organization',
+      ])
+      ->setRecords([
+        ['organization_name' => 'The org'],
+        ['organization_name' => 'The org Ltd.'],
+        ['organization_name' => 'This is fine'],
+      ])
+      ->execute()->column('id', 'organization_name');
+    $this->contactIdsToDelete = array_keys($contacts);
+
+    Civi::settings()->set('thethe_org_prefix_strings', 'The ');
+    Civi::settings()->set('thethe_org_anywhere_strings', '');
+    Civi::settings()->set('thethe_org_suffix_strings', ' Ltd.');
+
+    $results = Contact::applyThethe(FALSE)->addWhere('id', '>', 0)->execute()->column('sort_name', 'organization_name');
+    // We expect 2 rows returned because only 2 needed changing.
+    $this->assertCount(2, $results);
+    $this->assertEquals($results['The org'], 'org');
+    $this->assertEquals($results['The org Ltd.'], 'org');
+
+    // Reload to check the data was written as expected.
+    $reloaded = Contact::get(FALSE)
+      ->addSelect('organization_name', 'sort_name')
+      ->addWhere('id', 'IN', $contacts)
+      ->execute()->column('sort_name', 'organization_name');
+    $this->assertEquals($reloaded['The org'], 'org');
+    $this->assertEquals($reloaded['The org Ltd.'], 'org');
+    $this->assertEquals($reloaded['This is fine'], 'This is fine');
+
+    // Force all sort_name fields to be recreated.
+    $results = Contact::applyThethe(FALSE)
+      ->setWhereApplicable(FALSE)
+      ->addWhere('id', 'IN', $contacts)
+      ->execute()
+      ->column('sort_name', 'organization_name');
+    // We expect 3 rows returned this time.
+    $this->assertCount(3, $results);
+    $this->assertEquals($results['The org'], 'org');
+    $this->assertEquals($results['The org Ltd.'], 'org');
+    $this->assertEquals($results['This is fine'], 'This is fine');
+  }
+
+  public function tearDown(): void {
+    if ($this->contactIdsToDelete) {
+      Contact::delete(FALSE)
+        ->setUseTrash(FALSE)
+        ->addWhere('id', 'IN', $this->contactIdsToDelete)
+        ->execute();
+    }
+    parent::tearDown();
   }
 
 }

--- a/tests/phpunit/TheTheTest.php
+++ b/tests/phpunit/TheTheTest.php
@@ -96,6 +96,7 @@ class TheTheTest extends \PHPUnit\Framework\TestCase implements HeadlessInterfac
       'quoted' => ["'the '", ['the ']],
       'php array' => [['the '], ['the ']],
       'quoted csv empty item' => ["'the ','a ',", ['the ', 'a ']],
+      'Can include single quotes escaped with backslash' => ["'\\''", ["'"]],
     ];
   }
 

--- a/tests/phpunit/TheTheTest.php
+++ b/tests/phpunit/TheTheTest.php
@@ -55,4 +55,14 @@ class TheTheTest extends \PHPUnit\Framework\TestCase implements HeadlessInterfac
     $this->assertEquals('Top 10', $organization['sort_name']);
   }
 
+  /**
+   */
+  public function testCaseRules() {
+    Civi::settings()->set('thethe_org_prefix_strings', 'université de');
+    Civi::settings()->set('thethe_org_suffix_strings', 'Ltd');
+    Civi::settings()->set('thethe_org_anywhere_strings', ['and']);
+
+    $this->assertEquals('Life', thethe_munge('UNIVERSITÉ de Life LTD'));
+    $this->assertEquals('This And That', thethe_munge('The And That'));
+  }
 }

--- a/thethe.php
+++ b/thethe.php
@@ -81,7 +81,7 @@ function thethe_munge(string $orgName): string {
  *  - the
  *  - 'the '
  *  - 'the ', 'a ',
- *  - ['the ']
+ *  - ['the '] (i.e. a PHP array)
  *
  * @param string $settingName
  *   - prefix

--- a/thethe.php
+++ b/thethe.php
@@ -41,27 +41,35 @@ function thethe_civicrm_enable() {
 function thethe_civicrm_pre($op, $objectName, $id, &$params) {
   if ($objectName === 'Organization') {
     if (isset($params['organization_name'])) {
-
-      $params['sort_name'] = $params['organization_name'];
-      foreach (thethe_get_setting('prefix') as $string) {
-        if (strtolower(substr($params['sort_name'], 0, strlen($string))) === $string) {
-          $params['sort_name'] = substr($params['sort_name'], strlen($string));
-        }
-      }
-
-      foreach (thethe_get_setting('suffix') as $string) {
-        $suffixStart = strlen($params['sort_name']) - strlen($string);
-        if (strtolower(substr($params['sort_name'], $suffixStart, strlen($string))) === $string) {
-          $params['sort_name'] = substr($params['sort_name'], 0, $suffixStart);
-        }
-      }
-
-      foreach (thethe_get_setting('anywhere') as $string) {
-        $params['sort_name'] = str_replace($string, '', $params['sort_name']);
-      }
-      $params['sort_name'] = trim($params['sort_name']);
+      $params['sort_name'] = thethe_munge($params['organization_name']);
     }
   }
+}
+
+/**
+ * Return our munged sort name for the given Organization name.
+ */
+function thethe_munge(string $orgName): string {
+
+  foreach (thethe_get_setting('prefix') as $string) {
+    if (strtolower(substr($orgName, 0, strlen($string))) === $string) {
+      $orgName = substr($orgName, strlen($string));
+    }
+  }
+
+  foreach (thethe_get_setting('suffix') as $string) {
+    $suffixStart = strlen($orgName) - strlen($string);
+    if (strtolower(substr($orgName, $suffixStart, strlen($string))) === $string) {
+      $orgName = substr($orgName, 0, $suffixStart);
+    }
+  }
+
+  foreach (thethe_get_setting('anywhere') as $string) {
+    $orgName = str_replace($string, '', $orgName);
+  }
+  $orgName = trim($orgName);
+
+  return $orgName;
 }
 
 /**
@@ -104,8 +112,8 @@ function thethe_get_setting($settingName, $entity = 'org') {
  *
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_preProcess
  *
-
- // */
+ *
+ * // */
 
 /**
  * Implements hook_civicrm_navigationMenu().

--- a/thethe.php
+++ b/thethe.php
@@ -105,13 +105,14 @@ function thethe_parse_setting_value($strings): array {
   }
   if (!is_array($strings)) {
     // Parse single-quoted CSV
-    $remaining = trim((string) $strings);
+    $toLowerCase = function_exists('mb_strtolower') ? 'mb_strtolower' : 'strtolower';
+    $remaining = $toLowerCase(trim((string) $strings));
     $strings = [];
 
     while ($remaining) {
       if (preg_match('/^\'(.+?)(?<!\\\)\'/', $remaining, $matches)) {
         // Found quoted string.
-        $strings[] = $matches[1];
+        $strings[] = str_replace("\\'", "'", $matches[1]);
         // Remove the 'quoted' and any trailing comma or space
         $remaining = ltrim(substr($remaining, strlen($matches[0])), ' ,');
       }
@@ -123,10 +124,6 @@ function thethe_parse_setting_value($strings): array {
         Civi::log()->warning("Invalid TheThe pattern: $remaining");
       }
     }
-  }
-  $toLowerCase = function_exists('mb_strtolower') ? 'mb_strtolower' : 'strtolower';
-  foreach ($strings as $index => $string) {
-    $strings[$index] = $toLowerCase(trim($string, "'"));
   }
   return $strings;
 }

--- a/thethe.php
+++ b/thethe.php
@@ -51,15 +51,17 @@ function thethe_civicrm_pre($op, $objectName, $id, &$params) {
  */
 function thethe_munge(string $orgName): string {
 
+  $toLowerCase = function_exists('mb_strtolower') ? 'mb_strtolower' : 'strtolower';
+
   foreach (thethe_get_setting('prefix') as $string) {
-    if (strtolower(substr($orgName, 0, strlen($string))) === $string) {
+    if ($toLowerCase(substr($orgName, 0, strlen($string))) === $string) {
       $orgName = substr($orgName, strlen($string));
     }
   }
 
   foreach (thethe_get_setting('suffix') as $string) {
     $suffixStart = strlen($orgName) - strlen($string);
-    if (strtolower(substr($orgName, $suffixStart, strlen($string))) === $string) {
+    if ($toLowerCase(substr($orgName, $suffixStart, strlen($string))) === $string) {
       $orgName = substr($orgName, 0, $suffixStart);
     }
   }
@@ -99,8 +101,9 @@ function thethe_get_setting($settingName, $entity = 'org') {
   if (!is_array($strings)) {
     $strings = explode(',', $strings);
   }
+  $toLowerCase = function_exists('mb_strtolower') ? 'mb_strtolower' : 'strtolower';
   foreach ($strings as $index => $string) {
-    $strings[$index] = strtolower(trim($string, "'"));
+    $strings[$index] = $toLowerCase(trim($string, "'"));
   }
   return $strings;
 }


### PR DESCRIPTION
@eileenmcnaughton thanks for this, it's great!

This PR

- uses `mb_strtolower` where available
- adds a Contact.previewThethe action (a UI for this would be nice one day).
- updates README with some gotchas
- fixes some pattern parsing bugs (at least they looked like bugs!)
- updates tests, inc. one to document current behaviour that I don't know is definitely desired behaviour!
- adds a Contact.applyThethe action to apply the new rules to existing contacts.
